### PR TITLE
feat: role does not work on el10, aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ Configure and manage the Global File System 2 (gfs2), a cluster file system in a
 
 ## Supported Distributions
 
-* RHEL-8+, CentOS-8+
+* RHEL-8, RHEL-9, CentOS-8, CentOS-9
 * Fedora
+
+NOTE: gfs2 is not supported in EL10.
+
+### Architectures
+
+The role is not supported on these architectures:
+
+* aarch64
 
 ## Requirements
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
     - dlm
     - el8
     - el9
-    - el10
     - fedora
     - filesystem
     - gfs2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,13 @@
 - name: Set platform/version specific variables
   ansible.builtin.include_tasks: set_vars.yml
 
+- name: Check if role is supported on current architecture
+  fail:
+    msg: >-
+      The role is not supported on architecture
+      {{ ansible_facts["architecture"] }}
+  when: ansible_facts["architecture"] in ["aarch64"]
+
 - name: Install required packages
   ansible.builtin.include_tasks: install-packages.yml
 

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -9,5 +9,15 @@
     gfs2_file_systems: []
     _gfs2_test_allow_stonith_disabled: true
     gfs2_enable_repos: "{{ ansible_facts['distribution'] != 'RedHat' }}"
-  roles:
-    - linux-system-roles.gfs2
+  tasks:
+    - name: Run test
+      block:
+        - name: Run the role
+          include_role:
+            name: linux-system-roles.gfs2
+      rescue:
+        - name: Check role error on unsupported arch
+          assert:
+            that: __msg in ansible_failed_result.msg
+          vars:
+            __msg: The role is not supported on architecture

--- a/vars/CentOS_10.yml
+++ b/vars/CentOS_10.yml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: MIT
----
-__gfs2_repos:
-  - id: resilientstorage
-    name: ResilientStorage

--- a/vars/RedHat_10.yml
+++ b/vars/RedHat_10.yml
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: MIT
----
-__gfs2_repos:
-  - id: rhel-10-for-{{ ansible_architecture }}-resilientstorage-rpms
-    name: Resilient Storage

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,6 +7,7 @@ __gfs2_packages:
   - gfs2-utils
 # ansible_facts required by the role
 __gfs2_required_facts:
+  - architecture
   - distribution
   - distribution_major_version
   - distribution_version


### PR DESCRIPTION
gfs2 support is being removed in el10.
Replacement TBD.

Role does not support aarch64

Signed-off-by: Rich Megginson <rmeggins@redhat.com>