### PR TITLE
ci: ansible-test action now requires ansible-core version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -44,4 +44,5 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           testing-type: sanity  # wokeignore:rule=sanity
+          ansible-core-version: stable-2.17
           collection-src-directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}


### PR DESCRIPTION
The ansible-test github action does not use a supported version
of ansible-core by default.
https://github.com/ansible-community/ansible-test-gh-action?tab=readme-ov-file#ansible-core-version

We have to set it in our action.  Using `stable-2.17` as that is the latest stable version.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
