### PR TITLE
fix: remove el10 support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
     - dlm
     - el8
     - el9
-    - el10
     - fedora
     - filesystem
     - gfs2


### PR DESCRIPTION
previous fixes for removing el10 support did not drop
el10 from meta/main.yml
