### PR TITLE
test: remove unused files [citest_skip]

### DIFF
--- a/ansible_pytest_extra_requirements.txt
+++ b/ansible_pytest_extra_requirements.txt
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: MIT
 
 # ansible and dependencies for all supported platforms
-ansible ; python_version > "2.6"
-idna<2.8 ; python_version < "2.7"
-PyYAML<5.1 ; python_version < "2.7"
+ansible-core ; python_version > "2.6"

--- a/pytest_extra_requirements.txt
+++ b/pytest_extra_requirements.txt
@@ -1,7 +1,4 @@
 # SPDX-License-Identifier: MIT
 
 # ansible and dependencies for all supported platforms
-ansible ; python_version > "2.6"
-ansible<2.7 ; python_version < "2.7"
-idna<2.8 ; python_version < "2.7"
-PyYAML<5.1 ; python_version < "2.7"
+ansible-core ; python_version > "2.6"


### PR DESCRIPTION
Remove py26 requirements

Use ansible-core instead of ansible - much smaller

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
